### PR TITLE
feat: configurable card title property and max properties limit

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -9,7 +9,12 @@ import {
   Menu,
 } from "obsidian";
 import { KanbanView } from "./kanban-view";
-import { ORDER_PROPERTY, sanitizeFilename } from "./constants";
+import {
+  ORDER_PROPERTY,
+  CONFIG_KEY_TITLE_PROPERTY,
+  CONFIG_KEY_MAX_PROPERTIES,
+  sanitizeFilename,
+} from "./constants";
 import { relativeLuminance } from "./color-utils";
 import { CardDetailModal } from "./card-detail-modal";
 
@@ -179,7 +184,20 @@ export class CardManager {
     }
 
     const titleEl = cardEl.createDiv({ cls: "base-board-card-title" });
-    titleEl.createEl("span", { text: entry.file?.basename ?? "Untitled" });
+    const titleProp = this.view.config?.get(CONFIG_KEY_TITLE_PROPERTY) as
+      | string
+      | undefined;
+    let displayTitle = entry.file?.basename ?? "Untitled";
+    if (titleProp) {
+      const propId: BasesPropertyId = (
+        titleProp.startsWith("note.") ? titleProp : `note.${titleProp}`
+      ) as BasesPropertyId;
+      const val = entry.getValue(propId);
+      if (val && !(val instanceof NullValue) && val.isTruthy()) {
+        displayTitle = val.toString();
+      }
+    }
+    titleEl.createEl("span", { text: displayTitle });
 
     // ---- Edit button (visible on hover) ----
     const editBtn = cardEl.createDiv({ cls: "base-board-card-edit-btn" });
@@ -195,9 +213,13 @@ export class CardManager {
     // Use the official API: getOrder() returns the user-configured visible
     // properties in the order set via the Properties toolbar menu.
     const visibleProps: BasesPropertyId[] = this.view.config.getOrder();
+    const maxProps =
+      (this.view.config?.get(CONFIG_KEY_MAX_PROPERTIES) as
+        | number
+        | undefined) ?? 3;
     let shown = 0;
     for (const propId of visibleProps) {
-      if (shown >= 3) break;
+      if (shown >= maxProps) break;
       // Skip formula properties (not user-readable as chips).
       if (propId.startsWith("formula.")) continue;
       // For file.* properties, only skip ones that are redundant (name/path

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,26 @@ export const CONFIG_KEY_COLUMNS = "boardColumns";
 export const CONFIG_KEY_TAG_COLORS = "tagColors";
 
 /**
+ * Key used by BasesViewConfig.set/get to specify which frontmatter property
+ * to display as the card title instead of the filename.
+ *
+ * When set, the card title shows the value of this property (e.g. "raw_title")
+ * with a fallback to the file basename if the property is empty or missing.
+ *
+ * Accepts either a bare property name ("raw_title") or a Bases property ID
+ * ("note.raw_title").
+ */
+export const CONFIG_KEY_TITLE_PROPERTY = "cardTitleProperty";
+
+/**
+ * Key used by BasesViewConfig.set/get to control the maximum number of
+ * property chips displayed on each card.
+ *
+ * Defaults to 3 when not set.
+ */
+export const CONFIG_KEY_MAX_PROPERTIES = "maxCardProperties";
+
+/**
  * Regex matching characters that are invalid in file/folder names.
  * Used when sanitizing user input before creating vault items.
  */


### PR DESCRIPTION
## Summary

- **`cardTitleProperty`**: new `.base` config option to display a frontmatter property (e.g. `raw_title`) as the card title instead of the filename. Falls back to `file.basename` when the property is empty, missing, or not configured — fully backwards-compatible.
- **`maxCardProperties`**: new `.base` config option to control the maximum number of property chips on each card. Defaults to `3` (current behavior).

Both options use the existing `BasesViewConfig.set/get` pattern, consistent with `boardColumns` and `tagColors`.

## Motivation

When filenames follow a technical convention (e.g. `2026-04-10-senior-laravel-dev-acme.md`), the card title is hard to read. Many users store a human-readable title in frontmatter (`title`, `raw_title`, etc.) that would be better suited as the card display name.

The 3-property limit on cards is also restrictive for boards with rich metadata — making it configurable lets users show more context at a glance.

## Example `.base` configuration

```yaml
views:
  - type: kanban
    name: My Board
    cardTitleProperty: raw_title
    maxCardProperties: 5
    groupBy:
      property: status
      direction: ASC
```

## Changes

- `src/constants.ts`: 2 new config key constants with JSDoc
- `src/card.ts`: ~15 lines — reads config, resolves property value with type-safe `BasesPropertyId` cast, falls back to basename

## Test plan

- [ ] Board with `cardTitleProperty` set shows frontmatter value as card title
- [ ] Board with `cardTitleProperty` set to a missing/empty property falls back to filename
- [ ] Board without `cardTitleProperty` behaves identically to before (backwards compat)
- [ ] Board with `maxCardProperties: 5` shows up to 5 property chips
- [ ] Board without `maxCardProperties` still shows max 3 (default)
- [ ] `npm run build` passes with no errors
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)