### PR TITLE
Render wikilinks as display text in property chips

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -2,11 +2,14 @@ import {
   BasesEntry,
   BasesPropertyId,
   DateValue,
+  LinkValue,
+  ListValue,
   NullValue,
   setIcon,
   TFile,
   Notice,
   Menu,
+  Value,
 } from "obsidian";
 import { KanbanView } from "./kanban-view";
 import { ORDER_PROPERTY, sanitizeFilename } from "./constants";
@@ -26,6 +29,41 @@ function generateCardId(title: string): string {
     () => SUFFIX_CHARS[Math.floor(Math.random() * SUFFIX_CHARS.length)],
   ).join("");
   return `${slug}-${suffix}`;
+}
+
+// Format a Value for chip display:
+//   - DateValue    → relative ("3 days ago")
+//   - LinkValue    → alias if set, otherwise basename without .md extension
+//                    (e.g. [[folder/Mario]] → "Mario", [[Welcome|Alias]] → "Alias")
+//   - ListValue    → comma-separated list of the above, applied recursively
+//   - everything else → toString() (existing behaviour)
+function formatValueForChip(val: Value): string {
+  if (val instanceof DateValue) {
+    return val.relative();
+  }
+  if (val instanceof LinkValue) {
+    const raw = val.toString();
+    const match = raw.match(/^\[\[([^|\]]+)(?:\|([^\]]+))?\]\]$/);
+    if (match) {
+      const target = match[1];
+      const alias = match[2];
+      if (alias) return alias;
+      const basename = target.split("/").pop() ?? target;
+      return basename.replace(/\.md$/, "");
+    }
+    return raw;
+  }
+  if (val instanceof ListValue) {
+    const parts: string[] = [];
+    const len = val.length();
+    for (let i = 0; i < len; i++) {
+      const item = val.get(i);
+      if (!item || item instanceof NullValue || !item.isTruthy()) continue;
+      parts.push(formatValueForChip(item));
+    }
+    return parts.join(", ");
+  }
+  return val.toString();
 }
 
 // File properties that are redundant (shown as the card title) or are
@@ -215,8 +253,7 @@ export class CardManager {
       if (!val || val instanceof NullValue || !val.isTruthy()) continue;
       // Use relative time for dates (e.g. "3 days ago") — much more readable
       // on a card chip than a raw ISO string or a full locale date.
-      const display =
-        val instanceof DateValue ? val.relative() : val.toString();
+      const display = formatValueForChip(val);
       if (!display) continue;
 
       const chip = propsEl.createEl("span", {


### PR DESCRIPTION
## Problem

When a frontmatter property contains a wikilink (e.g. `asignado: "[[Mario]]"` or `desarrollador: ["[[Mario]]", "[[Julia]]"]`), the card chip renders the raw string:

```
Asignado [[Mario]]
Desarrollador [[Mario]], [[Julia]]
```

That's because the existing code does `val.toString()`, and `LinkValue.toString()` returns the raw `[[...]]` form. It breaks the visual flow of the kanban, especially when properties are used to assign people or relate cards to other notes.

## Change

A small helper `formatValueForChip(val: Value): string` in `src/card.ts`:

- `DateValue` → `.relative()` (same as before)
- `LinkValue` → alias if present, otherwise the basename of the target (without the `.md` extension)
- `ListValue` → recursively formats each element and joins with `, `
- Anything else → `.toString()` (unchanged behaviour)

Examples:

| Frontmatter | Before | After |
|---|---|---|
| `asignado: "[[Mario]]"` | `[[Mario]]` | `Mario` |
| `page: "[[Welcome\|Intro]]"` | `[[Welcome\|Intro]]` | `Intro` |
| `parent: "[[folder/Notes]]"` | `[[folder/Notes]]` | `Notes` |
| `team: ["[[Mario]]", "[[Julia]]"]` | `[[Mario]], [[Julia]]` | `Mario, Julia` |

No API changes, no behaviour change for non-link values.

## Testing

Manually verified in a vault with properties of type wikilink (single) and list-of-wikilinks on multiple boards. Chips render the human-readable label; hovering/clicking on the card still works.

Pairs well with the existing feature request to trim `#` from tag chips (#6) — same spirit, different value type.