### PR TITLE
feat/folder filter refresh

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -10,6 +10,10 @@ if you want to view the source, please visit the github repository of this plugi
 
 const prod = process.argv[2] === "production";
 
+// Where `npm run dev` writes the bundle. Set this to your vault's plugin
+// folder (e.g. "/path/to/Vault/.obsidian/plugins/base-board") to auto-deploy
+const PLUGIN_DEV_DIR = ".";
+
 const context = await esbuild.context({
   banner: {
     js: banner,
@@ -37,7 +41,7 @@ const context = await esbuild.context({
   logLevel: "info",
   sourcemap: prod ? false : "inline",
   treeShaking: true,
-  outfile: "main.js",
+  outfile: prod ? "main.js" : `${PLUGIN_DEV_DIR}/main.js`,
 });
 
 if (prod) {

--- a/src/folder-rename.ts
+++ b/src/folder-rename.ts
@@ -1,0 +1,63 @@
+/**
+ * Matches a quoted path passed as a function argument, splitting it into parts
+ * so the path can be swapped without disturbing surrounding whitespace/quotes:
+ *
+ *   group 1 — the opening "(", any whitespace, and the opening quote
+ *   group 2 — the quote character (single or double), reused via \2
+ *   group 3 — the quoted path itself
+ *   group 4 — the closing quote, any whitespace, and the closing ")"
+ *
+ * Function-name agnostic: it matches `inFolder("…")`, `hasLink("…")`,
+ * `path.startsWith("…")`, `linksTo("…")`, ...
+ * The "must be inside (...)" shape keeps us away from YAML scalars (view names,
+ * property names) and `==` comparisons, which we do not want to touch.
+ */
+const FILTER_PATH_ARG_PATTERN = /(\(\s*(["']))(.*?)(\2\s*\))/g;
+
+/**
+ * Rewrite folder/file path references inside a .base file's text after a folder
+ * was renamed or moved from `oldPath` to `newPath`.
+ *
+ * Pure function — text in, text out.  Returns the updated content, or `null`
+ * when nothing matched, so the caller can skip writing unchanged files.
+ *
+ * Matching is conservative and case-sensitive: a quoted argument
+ * is only rewritten when it is exactly `oldPath` or a descendant
+ * (`oldPath + "/…"`).
+ */
+export function updateBaseFolderReferences(
+  content: string,
+  oldPath: string,
+  newPath: string,
+): string | null {
+  if (!oldPath || oldPath === newPath) return null;
+
+  let changed = false;
+
+  const updated = content.replace(
+    FILTER_PATH_ARG_PATTERN,
+    (
+      match: string,
+      pre: string,
+      _quote: string,
+      path: string,
+      post: string,
+    ) => {
+      let newInnerPath: string | null = null;
+
+      if (path === oldPath) {
+        // Exact match: the argument targets the renamed folder/file itself.
+        newInnerPath = newPath;
+      } else if (path.startsWith(oldPath + "/")) {
+        // Descendant: keep everything after the renamed segment intact.
+        newInnerPath = newPath + path.slice(oldPath.length);
+      }
+
+      if (newInnerPath === null) return match; // not a match — leave untouched
+      changed = true;
+      return pre + newInnerPath + post;
+    },
+  );
+
+  return changed ? updated : null;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,15 @@
-import { Plugin, Notice, QueryController, TFile } from "obsidian";
+import {
+  Plugin,
+  Notice,
+  QueryController,
+  TFile,
+  TFolder,
+  TAbstractFile,
+} from "obsidian";
 import { KanbanView } from "./kanban-view";
 import { sanitizeFilename } from "./constants";
 import { CreateBoardModal, BoardConfig } from "./modals";
+import { updateBaseFolderReferences } from "./folder-rename";
 
 /** Per-base column configuration */
 export interface ColumnConfig {
@@ -22,6 +30,12 @@ const DEFAULT_DATA: PluginData = {
 
 export default class BaseBoardPlugin extends Plugin {
   data_: PluginData = DEFAULT_DATA;
+
+  /** Folder rename mappings collected during one rename burst, pending flush. */
+  private pendingFolderRenames: Array<{ oldPath: string; newPath: string }> =
+    [];
+  /** Debounce timer that flushes pendingFolderRenames once the burst settles. */
+  private folderRenameFlushTimer: number | null = null;
 
   async onload() {
     await this.loadPluginData();
@@ -44,9 +58,86 @@ export default class BaseBoardPlugin extends Plugin {
         }).open();
       },
     });
+
+    // -- Keep board filters in sync when their folder is renamed/moved --------
+    this.registerEvent(
+      this.app.vault.on("rename", (file, oldPath) => {
+        this.handleFolderRename(file, oldPath);
+      }),
+    );
   }
 
-  onunload() {}
+  onunload() {
+    if (this.folderRenameFlushTimer !== null) {
+      window.clearTimeout(this.folderRenameFlushTimer);
+    }
+  }
+
+  // -- Folder rename sync -----------------------------------------------------
+
+  /**
+   * When a folder is renamed or moved, rewrite any .base board filter that
+   * pointed at the old path so the board keeps working without a manual edit.
+   *
+   * To avoid race condition, burst of renaming events are collected, and once
+   * a timeout is reached we flush and modify the path mappings in .base
+   */
+  private handleFolderRename(file: TAbstractFile, oldPath: string): void {
+    const timeOut = 250;
+
+    // Only folder moves change the folder a filter targets; ignore file renames.
+    if (!(file instanceof TFolder)) return;
+
+    const newPath = file.path;
+    if (newPath === oldPath) return;
+
+    this.pendingFolderRenames.push({ oldPath, newPath });
+
+    // Debounce: reset the timer on every event so the flush runs only after
+    // the rename burst has settled and Obsidian has finished moving files.
+    if (this.folderRenameFlushTimer !== null) {
+      window.clearTimeout(this.folderRenameFlushTimer);
+    }
+    this.folderRenameFlushTimer = window.setTimeout(() => {
+      this.folderRenameFlushTimer = null;
+      void this.flushFolderRenames();
+    }, timeOut);
+  }
+
+  /** Apply all pending folder-rename mappings to every .base file. */
+  private async flushFolderRenames(): Promise<void> {
+    const renames = this.pendingFolderRenames;
+    this.pendingFolderRenames = [];
+    if (renames.length === 0) return;
+
+    const baseFiles = this.app.vault
+      .getFiles()
+      .filter((f) => f.extension === "base");
+
+    let updatedCount = 0;
+    for (const baseFile of baseFiles) {
+      try {
+        let content = await this.app.vault.read(baseFile);
+        let changed = false;
+        for (const { oldPath, newPath } of renames) {
+          const updated = updateBaseFolderReferences(content, oldPath, newPath);
+          if (updated !== null) {
+            content = updated;
+            changed = true;
+          }
+        }
+        if (changed) {
+          await this.app.vault.modify(baseFile, content);
+          updatedCount++;
+        }
+      } catch (err) {
+        console.error(
+          `Base Board: failed to update folder references in "${baseFile.path}"`,
+          err,
+        );
+      }
+    }
+  }
 
   // -- Board scaffolding ------------------------------------------------------
 


### PR DESCRIPTION
## Problem

When folder are renamed / moved, filters in the board are not modified. Thus we need to manually modify them to make the board working again. 

## Change

Added a function `updateBaseFolderReferences(content, oldPath, newPath)` that updates a quoted path inside any filter call (`inFolder`, `hasLink`, `path.startsWith`, …) when that path exactly equals the renamed folder or a descendant. Case-sensitive, ignores YAML values and == comparisons.

Added a vault rename listener that collects folder renames, and after short time, rewrites matching paths in every `.base` file.

Added a `PLUGIN_DEV_DIR` variable to specify the output destination when building in dev.

## Testing

Manually verified in a vault, with multiples tasks with such filter constraint :
- `is in folder W`
- `is not in folder X`
- `does link to file Y`
- `does not link to file Z`
- `starts with X`

<img width="1893" height="1105" alt="image" src="https://github.com/user-attachments/assets/7d3ccead-f151-4b16-a236-28171450d59e" />

