### PR TITLE
fix: rename inputs throw HierarchyRequestError (createEl on document)

### DIFF
--- a/src/card.ts
+++ b/src/card.ts
@@ -430,7 +430,7 @@ export class CardManager {
     const titleSpan = titleEl.querySelector("span");
     if (!titleSpan) return;
 
-    const input = activeDocument.createEl("input");
+    const input = activeDocument.createElement("input");
     input.type = "text";
     input.value = file.basename;
     input.className = "base-board-card-rename-input";

--- a/src/column.ts
+++ b/src/column.ts
@@ -206,7 +206,7 @@ export class ColumnManager {
     countEl?: HTMLElement | null,
     addCardBtn?: HTMLElement | null,
   ): void {
-    const input = activeDocument.createEl("input");
+    const input = activeDocument.createElement("input");
     input.type = "text";
     input.value = oldName;
     input.className = "base-board-column-title-input";


### PR DESCRIPTION
## Summary

Renaming a column (and renaming a card) throws and silently does nothing. The inline edit `<input>` is never created.

## The error

```
Uncaught HierarchyRequestError: Failed to execute 'appendChild' on 'Node': Only one element on document allowed.
    at window.createEl (enhance.js)
    at Node.createEl (enhance.js)
    at ColumnManager.startColumnRename (plugin:base-board)
```

## Root cause

`startColumnRename` and `startCardRename` create the inline input with:

```ts
const input = activeDocument.createEl("input");
```

Obsidian's `createEl` **appends** the newly created element to the node it's called on. Calling it on `activeDocument` (the `Document`) makes it `appendChild` to the document root — but a document may only have one element child (`<html>`), so it throws `HierarchyRequestError`.

The input is attached to the DOM immediately afterward via `titleEl.replaceWith(input)` / `titleSpan.replaceWith(input)`, so it only needs to be created **detached**.

## Fix

Use `createElement` (creates a detached element, no implicit append):

```ts
const input = activeDocument.createElement("input");
```

Applied in both spots:
- `src/column.ts` — `startColumnRename` (column rename)
- `src/card.ts` — `startCardRename` (card rename)

## Verification

- `npm run build` (tsc type-check + esbuild production) passes.
- Manually verified on Obsidian 1.12.7: column and card rename now open the inline input and commit correctly.

## Notes

This surfaces as a hard throw on recent Obsidian (1.12.x), where `createEl` on a `Document` rejects the append; on older builds it failed more quietly. `createElement` is correct regardless of version.
