### PR TITLE
Add per-column work in progress limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - **Tags**: Color-coded tag chips on cards with a clickable filter bar to narrow the board by tag.
 - **Hover Preview**: Native note previews on hover (uses the **Page preview** core plugin).
 - **One-Click Creation**: Add new notes directly to a specific column without leaving the board view.
+- **WIP Limits**: Set per-column work-in-progress limits via the column header context menu. Columns that exceed their limit are highlighted in red.
 - **Data First**: All changes are written directly to your Markdown files.
 
 ## Usage

--- a/src/column.ts
+++ b/src/column.ts
@@ -10,6 +10,7 @@ import { KanbanView } from "./kanban-view";
 import { InputModal } from "./modals";
 import { NO_VALUE_COLUMN } from "./constants";
 import { ColorPickerModal } from "./tags";
+import { WipLimitModal } from "./modals";
 
 export class ColumnManager {
   private view: KanbanView;
@@ -51,6 +52,12 @@ export class ColumnManager {
     columnEl.dataset.columnName = columnName;
     columnEl.dataset.columnIndex = String(columnIndex);
 
+    // ---- WIP limit check ----
+    const wipLimit = this.view.getWipLimit(columnName);
+    if (wipLimit !== null && entries.length > wipLimit) {
+      columnEl.addClass("base-board-column--wip-overflow");
+    }
+
     const columnColor = this.view.getColumnColor(columnName);
     if (columnColor) {
       columnEl.style.setProperty("--column-color", columnColor);
@@ -77,8 +84,13 @@ export class ColumnManager {
     }
 
     // Count badge sits right after the title, inline
+    // Show "count / limit" when a WIP limit is set
+    const countText =
+      wipLimit !== null
+        ? `${entries.length} / ${wipLimit}`
+        : String(entries.length);
     const countEl = headerEl.createSpan({
-      text: String(entries.length),
+      text: countText,
       cls: "base-board-column-count",
     });
 
@@ -137,6 +149,27 @@ export class ColumnManager {
               currentColor,
               (color) => {
                 this.view.setColumnColor(columnName, color);
+              },
+            ).open();
+          });
+      });
+
+      const currentWipLimit = this.view.getWipLimit(columnName);
+      menu.addItem((item) => {
+        item
+          .setTitle(
+            currentWipLimit !== null
+              ? `WIP limit: ${currentWipLimit}`
+              : "Set WIP limit",
+          )
+          .setIcon("lucide-gauge")
+          .onClick(() => {
+            new WipLimitModal(
+              this.view.app,
+              columnName,
+              currentWipLimit,
+              (limit) => {
+                this.view.setWipLimit(columnName, limit);
               },
             ).open();
           });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,9 @@ export const CONFIG_KEY_OPEN_BEHAVIOR = "cardOpenBehavior";
 /** Key used by BasesViewConfig.set/get to persist column colors in the .base file. */
 export const CONFIG_KEY_COLUMN_COLORS = "columnColors";
 
+/** Key used by BasesViewConfig.set/get to persist per-column WIP limits. */
+export const CONFIG_KEY_WIP_LIMITS = "wipLimits";
+
 /**
  * Regex matching characters that are invalid in file/folder names.
  * Used when sanitizing user input before creating vault items.

--- a/src/kanban-view.ts
+++ b/src/kanban-view.ts
@@ -22,6 +22,7 @@ import {
   CONFIG_KEY_COLUMNS,
   CONFIG_KEY_OPEN_BEHAVIOR,
   CONFIG_KEY_COLUMN_COLORS,
+  CONFIG_KEY_WIP_LIMITS,
 } from "./constants";
 
 // ---------------------------------------------------------------------------
@@ -251,6 +252,34 @@ export class KanbanView extends BasesView implements HoverParent {
       delete colors[columnName];
     }
     this.config?.set(CONFIG_KEY_COLUMN_COLORS, colors);
+    this.scheduleRender();
+  }
+
+  // ---------------------------------------------------------------------------
+  //  WIP Limits
+  // ---------------------------------------------------------------------------
+
+  public getWipLimits(): Record<string, number> {
+    const raw = this.config?.get(CONFIG_KEY_WIP_LIMITS);
+    return raw && typeof raw === "object"
+      ? (raw as Record<string, number>)
+      : {};
+  }
+
+  public getWipLimit(columnName: string): number | null {
+    const limits = this.getWipLimits();
+    const val = limits[columnName];
+    return typeof val === "number" && val > 0 ? val : null;
+  }
+
+  public setWipLimit(columnName: string, limit: number | null): void {
+    const limits = this.getWipLimits();
+    if (limit !== null && limit > 0) {
+      limits[columnName] = limit;
+    } else {
+      delete limits[columnName];
+    }
+    this.config?.set(CONFIG_KEY_WIP_LIMITS, limits);
     this.scheduleRender();
   }
 

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -1,4 +1,5 @@
 import { Modal, App, Setting, Notice, TextComponent } from "obsidian";
+import { CONFIG_KEY_WIP_LIMITS } from "./constants";
 
 // ---------------------------------------------------------------------------
 //  Simple input modal (for column names, etc.)
@@ -60,6 +61,90 @@ export class InputModal extends Modal {
     const trimmed = this.value.trim();
     if (trimmed) {
       this.onSubmit(trimmed);
+    }
+    this.close();
+  }
+
+  onClose(): void {
+    this.contentEl.empty();
+  }
+}
+
+// ---------------------------------------------------------------------------
+//  WIP Limit modal (set/remove per-column WIP limits)
+// ---------------------------------------------------------------------------
+
+export class WipLimitModal extends Modal {
+  private columnName: string;
+  private currentLimit: number | null;
+  private onSubmit: (limit: number | null) => void;
+  private value = "";
+
+  constructor(
+    app: App,
+    columnName: string,
+    currentLimit: number | null,
+    onSubmit: (limit: number | null) => void,
+  ) {
+    super(app);
+    this.columnName = columnName;
+    this.currentLimit = currentLimit;
+    this.onSubmit = onSubmit;
+    this.value = currentLimit !== null ? String(currentLimit) : "";
+  }
+
+  onOpen(): void {
+    const { contentEl } = this;
+    contentEl.createEl("h3", { text: `WIP limit: ${this.columnName}` });
+
+    new Setting(contentEl)
+      .setName("Maximum cards")
+      .setDesc("Leave empty to remove the limit")
+      .addText((text) => {
+        text.setPlaceholder("e.g. 5");
+        if (this.currentLimit !== null) {
+          text.setValue(String(this.currentLimit));
+        }
+        text.onChange((v) => (this.value = v));
+        window.setTimeout(() => {
+          text.inputEl.focus();
+          text.inputEl.addEventListener("keydown", (e: KeyboardEvent) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              this.submit();
+            }
+          });
+        }, 50);
+      });
+
+    new Setting(contentEl).addButton((btn) => {
+      btn
+        .setButtonText("Save")
+        .setCta()
+        .onClick(() => this.submit());
+    });
+
+    if (this.currentLimit !== null) {
+      new Setting(contentEl).addButton((btn) => {
+        btn.setButtonText("Remove limit").onClick(() => {
+          this.onSubmit(null);
+          this.close();
+        });
+      });
+    }
+  }
+
+  private submit(): void {
+    const trimmed = this.value.trim();
+    if (trimmed === "") {
+      this.onSubmit(null);
+    } else {
+      const num = parseInt(trimmed, 10);
+      if (isNaN(num) || num <= 0) {
+        new Notice("WIP limit must be a positive number.");
+        return;
+      }
+      this.onSubmit(num);
     }
     this.close();
   }

--- a/styles.css
+++ b/styles.css
@@ -67,6 +67,29 @@
     transform 0.15s ease;
 }
 
+/* WIP overflow — red highlight */
+.base-board-column--wip-overflow {
+  border-color: var(--text-error, #e74c3c);
+  background-color: color-mix(
+    in srgb,
+    var(--text-error, #e74c3c) 6%,
+    var(--background-secondary)
+  );
+}
+
+.base-board-column--wip-overflow .base-board-column-count {
+  background-color: color-mix(
+    in srgb,
+    var(--text-error, #e74c3c) 18%,
+    var(--background-secondary)
+  );
+  color: var(--text-error, #e74c3c);
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-weight: var(--font-semibold);
+  margin-left: 4px;
+}
+
 .base-board-column[style*="--column-color"] {
   background-color: color-mix(
     in srgb,


### PR DESCRIPTION
First of all -- love the plugin, been using it a lot recently!

One thing I felt was missing is WIP limits, which are kind of a core Kanban concept, so I gave it a shot and implemented a simple version of it.

You can now set a limit per column, and once it’s exceeded, the column gets visually highlighted. It doesn’t block anything — just gives a nice signal that things are piling up.

Added some screenshots to show how it looks in action.

<img width="415" height="380" alt="image" src="https://github.com/user-attachments/assets/bbc84a93-d908-4899-9e68-c3aa2af04266" />
<img width="346" height="285" alt="image" src="https://github.com/user-attachments/assets/caf8d70b-cbab-48a7-bab3-6c61cfa0fc5c" />
<img width="663" height="356" alt="image" src="https://github.com/user-attachments/assets/49e3e00c-c53d-48f4-a326-f7f8d52270fe" />

Also, full disclosure: this was heavily LLM-assisted, I'm not exactly frontend developer, but I went through the code and tested everything myself.