### PR TITLE
fix: improve card drag performance on desktop

### DIFF
--- a/src/drag-drop.ts
+++ b/src/drag-drop.ts
@@ -348,6 +348,16 @@ export class DragDropManager {
       e.clientY,
       "vertical",
     );
+
+    const desiredParent = cardsContainer;
+    const desiredNext = afterElement;
+    if (
+      this.placeholderEl.parentElement === desiredParent &&
+      this.placeholderEl.nextElementSibling === desiredNext
+    ) {
+      return;
+    }
+
     if (afterElement) {
       cardsContainer.insertBefore(this.placeholderEl, afterElement);
     } else {

--- a/src/drag-drop.ts
+++ b/src/drag-drop.ts
@@ -122,6 +122,7 @@ export class DragDropManager {
         this.placeholderEl.className = "base-board-column-placeholder";
         columnEl.parentElement?.insertBefore(this.placeholderEl, columnEl);
         columnEl.addClass("base-board-column--dragging");
+        this.boardEl?.addClass("base-board-board--is-dragging");
       });
       return;
     }
@@ -263,6 +264,7 @@ export class DragDropManager {
       this.placeholderEl.style.height = `${this.draggedCardHeight}px`;
       cardEl.parentElement?.insertBefore(this.placeholderEl, cardEl);
       cardEl.addClass("base-board-card--dragging");
+      this.boardEl?.addClass("base-board-board--is-dragging");
 
       // Dim all other selected cards during multi-drag
       if (isMultiDrag && this.boardEl) {
@@ -477,6 +479,8 @@ export class DragDropManager {
   }
 
   private onDragEnd(): void {
+    this.boardEl?.removeClass("base-board-board--is-dragging");
+
     // Stop any in-progress auto-scroll
     if (this.autoScrollRAF !== null) {
       cancelAnimationFrame(this.autoScrollRAF);

--- a/src/drag-drop.ts
+++ b/src/drag-drop.ts
@@ -35,6 +35,7 @@ export class DragDropManager {
   private autoScrollSpeed = 0; // horizontal (boardEl)
   private autoScrollVerticalSpeed = 0; // vertical (active cards container)
   private autoScrollVerticalEl: HTMLElement | null = null;
+  private lastDragOverColumn: HTMLElement | null = null;
 
   private boundHandlers: {
     dragStart: (e: DragEvent) => void;
@@ -321,14 +322,15 @@ export class DragDropManager {
     ) as HTMLElement | null;
 
     if (this.boardEl) {
-      const allColumns = this.boardEl.querySelectorAll(".base-board-column");
-      allColumns.forEach((col) => {
-        if (col === hoveredColumn) {
-          col.classList.add("base-board-column--drag-over");
-        } else {
-          col.classList.remove("base-board-column--drag-over");
-        }
-      });
+      const nextColumn =
+        hoveredColumn instanceof HTMLElement ? hoveredColumn : null;
+      if (nextColumn !== this.lastDragOverColumn) {
+        this.lastDragOverColumn?.classList.remove(
+          "base-board-column--drag-over",
+        );
+        nextColumn?.classList.add("base-board-column--drag-over");
+        this.lastDragOverColumn = nextColumn;
+      }
     }
 
     if (!cardsContainer) {
@@ -507,6 +509,7 @@ export class DragDropManager {
         .querySelectorAll(".base-board-column--drag-over")
         .forEach((col) => col.classList.remove("base-board-column--drag-over"));
     }
+    this.lastDragOverColumn = null;
     this.dragType = null;
   }
 

--- a/styles.css
+++ b/styles.css
@@ -543,6 +543,16 @@
   animation: base-board-placeholder-pulse 1.5s ease-in-out infinite;
 }
 
+/* Disable transitions during drag to avoid layout/paint backlog */
+.base-board-board--is-dragging .base-board-cards,
+.base-board-board--is-dragging .base-board-cards:empty,
+.base-board-board--is-dragging .base-board-card-placeholder,
+.base-board-board--is-dragging .base-board-card--drag-ghost,
+.base-board-board--is-dragging .base-board-column-placeholder {
+  transition: none !important;
+  animation: none !important;
+}
+
 /* ---- Add column button ---- */
 
 .base-board-add-column-btn {


### PR DESCRIPTION
> *This was drafted by Cursor.*

Fixes [#39]

## Summary

Fixes severe drag lag on desktop where card placeholders would keep "catching up" for several seconds after the mouse was released.

The root cause was redundant DOM work inside `handleCardDragOver` on every `dragover` event. Column drag already had a guard to skip unnecessary placeholder moves; card drag did not.

The placeholder guard (commit 1) is the core bugfix; commits 2–3 reduce remaining drag-over overhead and CSS paint cost during drag.

## Problem

While dragging a card, `dragover` fires at very high frequency on desktop. `handleCardDragOver` was:

- Toggling the drag-over highlight on **all** columns on every event
- Running `querySelectorAll` + `getBoundingClientRect()` on every card in the target column
- Calling `insertBefore` / `appendChild` on the placeholder **even when it was already in the correct position**

That combination caused layout thrashing and queued hundreds of slow event handlers. After `dragend`, the browser would still be processing the backlog — which matches the reported "catching up" behavior.

Column drag (`handleColumnDragOver`) already avoided this with an early-return when the placeholder position was unchanged.

## Solution

Three small, focused changes:

1. **Placeholder guard (bugfix)** — Mirror the existing column-drag logic in `handleCardDragOver`: only move the placeholder when its parent or next sibling actually changes.
2. **Column hover cache** — Track `lastDragOverColumn` and only toggle `base-board-column--drag-over` when the hovered column changes.
3. **Transition suppression** — Add `base-board-board--is-dragging` during drag and disable drag-related CSS transitions/animations while active.

## Changes

### `src/drag-drop.ts`

- Add `lastDragOverColumn` field to `DragDropManager`
- In `handleCardDragOver`: early-return before `insertBefore` when position is unchanged
- In `handleCardDragOver`: replace per-column loop with cached hover updates
- On drag start (card + column): add `base-board-board--is-dragging` inside the existing `requestAnimationFrame` callback
- In `onDragEnd`: remove dragging class and reset `lastDragOverColumn`

### `styles.css`

- Disable transitions and animations on drag-related elements while `.base-board-board--is-dragging` is active

## Commits

Split into three commits for easier review:

1. `fix: skip redundant card placeholder moves during dragover`
2. `perf: only update column drag-over highlight when hovered column changes`
3. `perf: disable drag-related CSS transitions while dragging`

## Test plan

- [x] Desktop: drag card within column — placeholder tracks instantly
- [x] Desktop: fast zig-zag mouse movement — no post-release catch-up
- [x] Drag card across columns
- [x] Drag card onto empty column (dashed drop zone appears)
- [x] Multi-select drag — ghost stack + count badge still works
- [x] Column header drag — reorder columns still works
- [x] Auto-scroll near board edges and column top/bottom still works
- [x] Mobile: no regression (no issues observed with Apple devices)