### PR TITLE
Add derived tags: surface frontmatter property values as virtual tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - **Rich Cards**: View key metadata fields as chips on each card for a quick overview.
 - **Configurable Card Title**: Set `cardTitleProperty: note.title` in your `.base` file to use a frontmatter property (e.g. `title`) as the card heading instead of the filename.
 - **Tags**: Color-coded tag chips on cards with a clickable filter bar to narrow the board by tag.
+- **Derived tags**: Optionally surface the values of other frontmatter properties (e.g. `assignee`, `priority`) as tags — they join the filter bar and card chips automatically, with no manual tagging, and are never written back to the note's `tags` frontmatter. Configure via the "Derive tags from properties" view option.
 - **Hover Preview**: Native note previews on hover (uses the **Page preview** core plugin).
 - **One-Click Creation**: Add new notes directly to a specific column without leaving the board view.
 - **WIP Limits**: Set per-column work-in-progress limits via the column header context menu. Columns that exceed their limit are highlighted in red.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,12 @@ export const CONFIG_KEY_COVER_PROPERTY = "cardCoverProperty";
 export const CONFIG_KEY_ADD_TO_TOP = "newCardsToTop";
 
 /**
+ * Key used by BasesViewConfig.set/get to persist the list of frontmatter
+ * properties whose values are surfaced as derived (virtual) tags.
+ */
+export const CONFIG_KEY_TAG_PROPERTIES = "tagProperties";
+
+/**
  * Regex matching characters that are invalid in file/folder names.
  * Used when sanitizing user input before creating vault items.
  */

--- a/src/derived-tags.ts
+++ b/src/derived-tags.ts
@@ -1,0 +1,57 @@
+/**
+ * Derived (virtual) tags — pure helpers.
+ *
+ * A board can be configured (via the "Derive tags from properties" view
+ * option) with a comma-separated list of frontmatter properties whose
+ * values are surfaced as tags in the filter bar and on cards.  Derived
+ * tags behave like normal tags for filtering and coloring, but are never
+ * written back to the note's `tags` frontmatter — the source property
+ * stays the single source of truth.
+ */
+
+/** Parse the raw "tagProperties" config value into property names. */
+export function parseTagProperties(raw: unknown): string[] {
+  if (typeof raw !== "string") return [];
+  return raw
+    .split(",")
+    .map((p) => p.trim().replace(/^note\./, ""))
+    .filter((p) => p);
+}
+
+/** Reduce a raw frontmatter value to a display tag (unwrap wikilinks). */
+export function normalizeDerivedValue(value: string): string {
+  const match = value.match(/^\[\[([^\]|]+?)(?:\|([^\]]+))?\]\]$/);
+  if (match) {
+    if (match[2]) return match[2].trim();
+    const target = match[1].trim();
+    return (target.split("/").pop() ?? target).replace(/\.md$/, "");
+  }
+  return value.trim();
+}
+
+/**
+ * Derive virtual tags from the given frontmatter.
+ *
+ * Each property in `props` contributes its value(s) as tags: list
+ * properties contribute one tag per item, and wikilink values
+ * ("[[Some Person]]" or "[[path/Some Person|Alias]]") are reduced to
+ * their display name.  Empty and non-scalar values are skipped.
+ */
+export function deriveTags(
+  frontmatter: Record<string, unknown> | undefined,
+  props: string[],
+): string[] {
+  if (!frontmatter || props.length === 0) return [];
+
+  const derived: string[] = [];
+  for (const prop of props) {
+    const raw = frontmatter[prop];
+    const values = Array.isArray(raw) ? raw : [raw];
+    for (const value of values) {
+      if (typeof value !== "string" && typeof value !== "number") continue;
+      const tag = normalizeDerivedValue(String(value));
+      if (tag && !derived.includes(tag)) derived.push(tag);
+    }
+  }
+  return derived;
+}

--- a/src/kanban-view.ts
+++ b/src/kanban-view.ts
@@ -32,6 +32,7 @@ import {
   CONFIG_KEY_WIP_LIMITS,
   CONFIG_KEY_COVER_PROPERTY,
   CONFIG_KEY_ADD_TO_TOP,
+  CONFIG_KEY_TAG_PROPERTIES,
 } from "./constants";
 
 interface BoardScrollState {
@@ -173,6 +174,13 @@ export class KanbanView extends BasesView implements HoverParent {
             type: "toggle" as const,
             displayName: "Add new cards to top",
             default: false,
+          },
+          {
+            key: CONFIG_KEY_TAG_PROPERTIES,
+            type: "text" as const,
+            displayName: "Derive tags from properties",
+            default: "",
+            placeholder: "E.g. assignee, priority",
           },
         ],
       },

--- a/src/tags.ts
+++ b/src/tags.ts
@@ -1,5 +1,6 @@
 import { KanbanView } from "./kanban-view";
-import { CONFIG_KEY_TAG_COLORS } from "./constants";
+import { CONFIG_KEY_TAG_COLORS, CONFIG_KEY_TAG_PROPERTIES } from "./constants";
+import { deriveTags, parseTagProperties } from "./derived-tags";
 import { App, Modal, TFile, setIcon, setTooltip, Setting } from "obsidian";
 import { TagEditModal } from "./tag-edit-modal";
 import { relativeLuminance } from "./color-utils";
@@ -73,11 +74,35 @@ export class Tags {
     }
     // Strip '#' prefix — Obsidian's MetadataCache sometimes normalises
     // frontmatter tags with a leading '#' (e.g. "#my-tag" instead of "my-tag").
-    return fileTags.map((t) => (t.startsWith("#") ? t.slice(1) : t));
+    const result = fileTags.map((t) => (t.startsWith("#") ? t.slice(1) : t));
+
+    // Append derived tags (from configured frontmatter properties), deduped.
+    for (const derived of this.deriveTagsFromProperties(file)) {
+      if (!result.includes(derived)) result.push(derived);
+    }
+    return result;
+  }
+
+  /** Frontmatter property names configured as derived-tag sources. */
+  public getTagProperties(): string[] {
+    return parseTagProperties(this.view.config?.get(CONFIG_KEY_TAG_PROPERTIES));
+  }
+
+  /** Derive virtual tags for a file from the configured properties. */
+  public deriveTagsFromProperties(file: TFile): string[] {
+    const props = this.getTagProperties();
+    if (props.length === 0) return [];
+    const fm = this.view.app.metadataCache.getFileCache(file)?.frontmatter;
+    return deriveTags(fm, props);
   }
 
   public promptEditTags(file: TFile): void {
-    const currentTags = this.extractTagsFromFile(file);
+    // Derived tags are excluded: they live in their source property, not in
+    // the `tags` frontmatter, so the edit modal must not re-persist them.
+    const derived = this.deriveTagsFromProperties(file);
+    const currentTags = this.extractTagsFromFile(file).filter(
+      (t) => !derived.includes(t),
+    );
     new TagEditModal(this.view.app, currentTags, this, (newTags: string[]) => {
       void this.view.app.fileManager.processFrontMatter(
         file,

--- a/tests/derived-tags.test.ts
+++ b/tests/derived-tags.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveTags,
+  normalizeDerivedValue,
+  parseTagProperties,
+} from "../src/derived-tags";
+
+describe("parseTagProperties", () => {
+  it("splits a comma-separated list and trims whitespace", () => {
+    expect(parseTagProperties("assignee, priority")).toEqual([
+      "assignee",
+      "priority",
+    ]);
+  });
+
+  it("strips an optional note. prefix", () => {
+    expect(parseTagProperties("note.assignee")).toEqual(["assignee"]);
+  });
+
+  it("returns [] for empty or non-string config", () => {
+    expect(parseTagProperties("")).toEqual([]);
+    expect(parseTagProperties("  ,  ")).toEqual([]);
+    expect(parseTagProperties(undefined)).toEqual([]);
+    expect(parseTagProperties(42)).toEqual([]);
+  });
+});
+
+describe("normalizeDerivedValue", () => {
+  it("passes plain values through, trimmed", () => {
+    expect(normalizeDerivedValue("  high ")).toBe("high");
+  });
+
+  it("unwraps wikilinks to their basename", () => {
+    expect(normalizeDerivedValue("[[Ada Lovelace]]")).toBe("Ada Lovelace");
+    expect(normalizeDerivedValue("[[People/Ada Lovelace.md]]")).toBe(
+      "Ada Lovelace",
+    );
+  });
+
+  it("prefers the wikilink alias when present", () => {
+    expect(normalizeDerivedValue("[[People/Ada Lovelace|Ada]]")).toBe("Ada");
+  });
+});
+
+describe("deriveTags", () => {
+  it("derives tags from scalar, wikilink, and list properties", () => {
+    const fm = {
+      assignee: "[[Ada Lovelace]]",
+      priority: "high",
+      area: ["ops", "dev"],
+    };
+    expect(deriveTags(fm, ["assignee", "priority", "area"])).toEqual([
+      "Ada Lovelace",
+      "high",
+      "ops",
+      "dev",
+    ]);
+  });
+
+  it("skips missing, empty, and non-scalar values", () => {
+    const fm = { assignee: "", nested: { a: 1 }, flag: true };
+    expect(deriveTags(fm, ["assignee", "nested", "flag", "absent"])).toEqual(
+      [],
+    );
+  });
+
+  it("dedupes values across properties", () => {
+    const fm = { a: "x", b: "x" };
+    expect(deriveTags(fm, ["a", "b"])).toEqual(["x"]);
+  });
+
+  it("returns [] without frontmatter or configured properties", () => {
+    expect(deriveTags(undefined, ["assignee"])).toEqual([]);
+    expect(deriveTags({ assignee: "x" }, [])).toEqual([]);
+  });
+
+  it("stringifies numeric values", () => {
+    expect(deriveTags({ priority: 1 }, ["priority"])).toEqual(["1"]);
+  });
+});


### PR DESCRIPTION
**Use case:** on a sprint board grouped by `status`, cards carry an `assignee` property. Today the only way to see/filter by person is to also maintain a person tag in `tags` frontmatter on every card, which goes stale the moment a card is reassigned.

This PR adds a **"Derive tags from properties"** view option (comma-separated property names, e.g. `assignee, priority`). The values of those properties join the filter bar and card chips exactly like frontmatter tags: clickable to filter, right-click to color.

- Wikilink values reduce to their display name (`[[People/Ada Lovelace|Ada]]` becomes `Ada`)
- List properties contribute one tag per item
- Derived tags are excluded from the Edit-tags modal, so they are never persisted into `tags`: the source property stays the single source of truth, and reassigning a card updates its pill with nothing stale left behind
- Empty option (the default) means zero behavior change

Pure logic lives in `src/derived-tags.ts` with unit tests (following the `order.ts`/`order.test.ts` pattern). `npm run build`, `npm test` (15/15), and `npm run lint` all pass. Happy to adjust naming or approach to fit your plans for the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
