### PR TITLE
Allow customizing the tasks folder name when creating a board

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,3 +38,16 @@ export const UNSAFE_FILENAME_CHARS = /[\\/:*?"<>|]/g;
 export function sanitizeFilename(name: string): string {
   return name.replace(UNSAFE_FILENAME_CHARS, "");
 }
+
+/**
+ * Sanitize a user-supplied string for use as a single folder name nested
+ * directly under another folder: strips characters invalid in file/folder
+ * names (via sanitizeFilename) and rejects "." / "..". Those contain no
+ * invalid characters on their own, but the latter would resolve outside the
+ * folder it's nested under and the former would represent the folder itself.
+ * Neither is permitted in the design.
+ */
+export function sanitizeFolderSegment(name: string): string {
+  const clean = sanitizeFilename(name);
+  return clean === "." || clean === ".." ? "" : clean;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import {
   TAbstractFile,
 } from "obsidian";
 import { KanbanView } from "./kanban-view";
-import { sanitizeFilename } from "./constants";
+import { sanitizeFilename, sanitizeFolderSegment } from "./constants";
 import { CreateBoardModal, BoardConfig } from "./modals";
 import { updateBaseFolderReferences } from "./folder-rename";
 
@@ -140,12 +140,14 @@ export default class BaseBoardPlugin extends Plugin {
   // -- Board scaffolding ------------------------------------------------------
 
   private async createBoard(config: BoardConfig): Promise<void> {
-    const { name, folder, groupBy } = config;
+    const { name, folder, groupBy, tasksFolder: tasksFolderName } = config;
     const vault = this.app.vault;
 
     // Sanitize folder path
     const safeFolder = folder.replace(/[\\:*?"<>|]/g, "");
-    const tasksFolder = `${safeFolder}/Tasks`;
+    const safeTasksFolderName =
+      sanitizeFolderSegment(tasksFolderName || "Tasks") || "Tasks";
+    const tasksFolder = `${safeFolder}/${safeTasksFolderName}`;
 
     // 1. Create folder structure
     if (!vault.getAbstractFileByPath(safeFolder)) {

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -161,6 +161,7 @@ export interface BoardConfig {
   name: string;
   folder: string;
   groupBy: string;
+  tasksFolder: string;
 }
 
 export class CreateBoardModal extends Modal {
@@ -168,6 +169,7 @@ export class CreateBoardModal extends Modal {
     name: "",
     folder: "",
     groupBy: "status",
+    tasksFolder: "Tasks",
   };
   private onSubmit: (config: BoardConfig) => void;
 
@@ -209,6 +211,16 @@ export class CreateBoardModal extends Modal {
         });
       });
 
+    // --- Tasks folder ---
+    new Setting(contentEl)
+      .setName("Tasks folder name")
+      .setDesc("Subfolder (inside the board folder) where task files live")
+      .addText((text) => {
+        text.setValue("Tasks");
+        text.setPlaceholder("Tasks");
+        text.onChange((v) => (this.config.tasksFolder = v || "Tasks"));
+      });
+
     // --- GroupBy property ---
     new Setting(contentEl)
       .setName("Group by property")
@@ -245,6 +257,7 @@ export class CreateBoardModal extends Modal {
     this.config.name = name;
     this.config.folder = this.config.folder.trim() || name;
     this.config.groupBy = this.config.groupBy.trim() || "status";
+    this.config.tasksFolder = this.config.tasksFolder.trim() || "Tasks";
     this.close();
     this.onSubmit(this.config);
   }

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeFolderSegment } from "../src/constants";
+
+describe("sanitizeFolderSegment", () => {
+  it("leaves a normal folder name untouched", () => {
+    expect(sanitizeFolderSegment("Tasks")).toBe("Tasks");
+  });
+
+  it("strips characters invalid in file/folder names", () => {
+    expect(sanitizeFolderSegment('Ta*sk?s<>"|')).toBe("Tasks");
+  });
+
+  it("strips slashes and backslashes rather than treating them as separators", () => {
+    expect(sanitizeFolderSegment("cards/here")).toBe("cardshere");
+    expect(sanitizeFolderSegment("cards\\here")).toBe("cardshere");
+  });
+
+  it("rejects '.' and '..' even though they contain no invalid characters", () => {
+    expect(sanitizeFolderSegment(".")).toBe("");
+    expect(sanitizeFolderSegment("..")).toBe("");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(sanitizeFolderSegment("")).toBe("");
+  });
+});


### PR DESCRIPTION
Hello.

In the current version of the plugin, the tasks-folder name is hardcoded to Tasks.  In some instances, it might be useful (I have a folder structure already) to be able to set it to a different value.  This PR adds a 'Tasks folder name' field to the 'Create new board' modal, with a default value of "Tasks" so existing behavior is unchanged if left as-is.

Changes

- New 'Tasks folder name' text field in `CreateBoardModal`, defaulting to "Tasks".

  <img width="581" height="448" alt="Screenshot 2026-07-22 at 09 22 56" src="https://github.com/user-attachments/assets/5cc87376-7bbe-4d4b-8682-b6b99fd17120" />

- `sanitizeFolderSegment()` in constants.ts: strips invalid filename characters (via existing `sanitizeFilename`) and additionally rejects "." and "..", since neither is filtered by `sanitizeFilename`, and both would break out of the board's own folder structure.  I've done this to preserve the "tasks folder is always a single subfolder nested directly under the board folder" behavior.
- Falls back to "Tasks" if sanitization empties the field entirely.

As far as I could tell, the tasks folder is put inside the inFolder query of the base, and then everything else just works from there: it is not explicitly referenced anywhere else in the code.  This, I think, makes the proposed changes self contained and safe.

Testing

I added, in the `tests/constants.test.ts` file, tests covering normal names, invalid-character stripping, slash/backslash handling, "."/".." rejection, and empty input.  I manually tested board creation as well as task creation and manipulation with a custom folder name in Obsidian.


I hope you think that would be useful and I'm definitely open to another approach that you think would better fit your general idea.
Thanks for the plugin.