### PR TITLE
feat: collapsible columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **Hover Preview**: Native note previews on hover (uses the **Page preview** core plugin).
 - **One-Click Creation**: Add new notes directly to a specific column without leaving the board view.
 - **WIP Limits**: Set per-column work-in-progress limits via the column header context menu. Columns that exceed their limit are highlighted in red.
+- **Collapsible Columns**: Collapse any column to save space; the state is remembered per board.
 - **Card Cover Images**: Display cover images at the top of cards by specifying an image frontmatter property (e.g., `cover: "[[image.png]]"` or a web URL). Defaults to the `cover` property.
 - **Data First**: All changes are written directly to your Markdown files.
 

--- a/src/column.ts
+++ b/src/column.ts
@@ -30,6 +30,7 @@ export class ColumnManager {
   ): void {
     const isNoValue = columnName === NO_VALUE_COLUMN;
     const entries = this.view.getEntriesForColumn(columnName, group);
+    const isCollapsed = this.view.isColumnCollapsed(columnName);
 
     // Sort entries up-front using a stable fallback
     const sorted = [...entries].sort((a: BasesEntry, b: BasesEntry) => {
@@ -71,6 +72,7 @@ export class ColumnManager {
     boardEl.appendChild(columnEl);
     columnEl.dataset.columnName = columnName;
     columnEl.dataset.columnIndex = String(columnIndex);
+    columnEl.classList.toggle("base-board-column--collapsed", isCollapsed);
 
     // ---- WIP limit check ----
     const wipLimit = this.view.getWipLimit(columnName);
@@ -93,6 +95,19 @@ export class ColumnManager {
       cls: "base-board-column-drag-handle",
     });
     setIcon(dragHandle, "grip-vertical");
+
+    const collapseBtn = headerEl.createEl("button", {
+      cls: "base-board-column-collapse-btn",
+      attr: {
+        type: "button",
+        "aria-label": isCollapsed ? "Expand column" : "Collapse column",
+      },
+    });
+    setIcon(collapseBtn, isCollapsed ? "chevron-right" : "chevron-down");
+    collapseBtn.addEventListener("click", (e: MouseEvent) => {
+      e.stopPropagation();
+      this.view.toggleColumnCollapsed(columnName);
+    });
 
     // Title + inline count badge
     const titleEl = headerEl.createSpan({
@@ -194,6 +209,8 @@ export class ColumnManager {
       existingCardsEl ?? columnEl.createDiv({ cls: "base-board-cards" });
     columnEl.appendChild(cardsEl);
 
+    // Cards render even when collapsed (CSS hides them) so the column stays a
+    // valid drop target that expands on drag-over.
     const visiblePaths = new Set(
       visibleCards.map((entry) => entry.file?.path ?? ""),
     );
@@ -329,6 +346,7 @@ export class ColumnManager {
   public handleDeleteColumn(columnName: string): void {
     const columns = this.view.getColumns().filter((c) => c !== columnName);
     this.view.saveColumns(columns);
+    this.view.removeColumnPreferences(columnName);
     this.view.render();
   }
 
@@ -407,6 +425,7 @@ export class ColumnManager {
       // 1. Update column config
       const updatedColumns = columns.map((c) => (c === oldName ? newName : c));
       this.view.saveColumns(updatedColumns);
+      this.view.updateColumnPreferences(oldName, newName);
 
       // 2. Update frontmatter for all cards in this column
       if (groupByProp) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,6 +7,9 @@ export const ORDER_PROPERTY = "kanban_order";
 /** Key used by BasesViewConfig.set/get to persist column order in the .base file. */
 export const CONFIG_KEY_COLUMNS = "boardColumns";
 
+/** Key used by BasesViewConfig.set/get to persist collapsed column state. */
+export const CONFIG_KEY_COLLAPSED_COLUMNS = "collapsedColumns";
+
 /** Key used by BasesViewConfig.set/get to persist custom tag colors in the .base file. */
 export const CONFIG_KEY_TAG_COLORS = "tagColors";
 

--- a/src/drag-drop.ts
+++ b/src/drag-drop.ts
@@ -343,8 +343,15 @@ export class DragDropManager {
       if (nextColumn !== this.lastDragOverColumn) {
         this.lastDragOverColumn?.classList.remove(
           "base-board-column--drag-over",
+          "base-board-column--drag-expanded",
         );
-        nextColumn?.classList.add("base-board-column--drag-over");
+        if (nextColumn) {
+          nextColumn.classList.add("base-board-column--drag-over");
+          // Expand a collapsed column so it can receive the drop.
+          if (nextColumn.classList.contains("base-board-column--collapsed")) {
+            nextColumn.classList.add("base-board-column--drag-expanded");
+          }
+        }
         this.lastDragOverColumn = nextColumn;
       }
     }
@@ -516,11 +523,17 @@ export class DragDropManager {
     }
     this.removePlaceholder();
     this.draggedEl = null;
-    // Remove all column drag-over highlights
     if (this.boardEl) {
       this.boardEl
-        .querySelectorAll(".base-board-column--drag-over")
-        .forEach((col) => col.classList.remove("base-board-column--drag-over"));
+        .querySelectorAll(
+          ".base-board-column--drag-over, .base-board-column--drag-expanded",
+        )
+        .forEach((col) =>
+          col.classList.remove(
+            "base-board-column--drag-over",
+            "base-board-column--drag-expanded",
+          ),
+        );
     }
     this.lastDragOverColumn = null;
     this.dragType = null;

--- a/src/kanban-view.ts
+++ b/src/kanban-view.ts
@@ -27,6 +27,7 @@ import {
   NO_VALUE_COLUMN,
   ORDER_PROPERTY,
   CONFIG_KEY_COLUMNS,
+  CONFIG_KEY_COLLAPSED_COLUMNS,
   CONFIG_KEY_OPEN_BEHAVIOR,
   CONFIG_KEY_COLUMN_COLORS,
   CONFIG_KEY_WIP_LIMITS,
@@ -465,6 +466,32 @@ export class KanbanView extends BasesView implements HoverParent {
     return dataColumns;
   }
 
+  public getCollapsedColumns(): Record<string, boolean> {
+    const raw = this.config?.get(CONFIG_KEY_COLLAPSED_COLUMNS);
+    return raw && typeof raw === "object"
+      ? (raw as Record<string, boolean>)
+      : {};
+  }
+
+  public isColumnCollapsed(columnName: string): boolean {
+    return !!this.getCollapsedColumns()[columnName];
+  }
+
+  public setColumnCollapsed(columnName: string, collapsed: boolean): void {
+    const state = this.getCollapsedColumns();
+    if (collapsed) {
+      state[columnName] = true;
+    } else {
+      delete state[columnName];
+    }
+    this.config?.set(CONFIG_KEY_COLLAPSED_COLUMNS, state);
+    this.scheduleRender();
+  }
+
+  public toggleColumnCollapsed(columnName: string): void {
+    this.setColumnCollapsed(columnName, !this.isColumnCollapsed(columnName));
+  }
+
   private getGroupForColumn(columnName: string): BasesEntryGroup | null {
     for (const group of this.currentGroups) {
       if (this.getColumnName(group.key) === columnName) {
@@ -635,6 +662,23 @@ export class KanbanView extends BasesView implements HoverParent {
 
     // Legacy fallback: also write to plugin data.json
     void this.plugin.saveColumnConfig(this.getBaseId(), { columns });
+  }
+
+  public updateColumnPreferences(oldName: string, newName: string): void {
+    const collapsed = this.getCollapsedColumns();
+    if (collapsed[oldName]) {
+      delete collapsed[oldName];
+      collapsed[newName] = true;
+      this.config?.set(CONFIG_KEY_COLLAPSED_COLUMNS, collapsed);
+    }
+  }
+
+  public removeColumnPreferences(columnName: string): void {
+    const collapsed = this.getCollapsedColumns();
+    if (collapsed[columnName]) {
+      delete collapsed[columnName];
+      this.config?.set(CONFIG_KEY_COLLAPSED_COLUMNS, collapsed);
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/styles.css
+++ b/styles.css
@@ -67,6 +67,10 @@
     transform 0.15s ease;
 }
 
+.base-board-column--collapsed {
+  max-height: none;
+}
+
 /* WIP overflow — red highlight */
 .base-board-column.base-board-column--wip-overflow[style*="--column-color"],
 .base-board-column.base-board-column--wip-overflow {
@@ -178,6 +182,31 @@
   cursor: grabbing;
 }
 
+.base-board-column-collapse-btn {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: var(--radius-s);
+  cursor: pointer;
+  padding: 0;
+}
+
+.base-board-column-collapse-btn:hover {
+  background-color: var(--background-modifier-hover);
+  color: var(--interactive-accent);
+}
+
+.base-board-column-collapse-btn svg {
+  width: 14px;
+  height: 14px;
+}
+
 .base-board-column-drag-handle {
   flex-shrink: 0;
   color: var(--text-faint);
@@ -275,6 +304,19 @@
   gap: 6px;
   min-height: 40px;
   transition: background-color 0.2s ease;
+}
+
+.base-board-column--collapsed > .base-board-cards {
+  display: none;
+}
+
+/* Collapsed column expands while a card is dragged over it */
+.base-board-column--collapsed.base-board-column--drag-expanded {
+  max-height: 100%;
+}
+
+.base-board-column--collapsed.base-board-column--drag-expanded > .base-board-cards {
+  display: flex;
 }
 
 /* ---- Empty column drop zone ---- */


### PR DESCRIPTION
Adds a collapse/expand toggle (chevron button) to every column header.

- Collapsed state is persisted **per board** in the `.base` file and survives column rename/delete.
- Cards in a collapsed column are hidden via CSS but stay in the DOM, so the
  column remains a **drag-and-drop target** — it temporarily expands while a
  card is dragged over it, then re-collapses.